### PR TITLE
More robust use of the invariant

### DIFF
--- a/src/Pair.sol
+++ b/src/Pair.sol
@@ -128,6 +128,8 @@ contract Pair is IPair {
         uint256 r1,
         uint256 shares
     ) public view returns (bool valid) {
+        if (shares == 0) return r0 == 0 && r1 == 0;
+
         uint256 scale0 = PRBMathUD60x18.div(PRBMathUD60x18.div(r0, shares), 10**baseScaleFactor);
         uint256 scale1 = PRBMathUD60x18.div(PRBMathUD60x18.div(r1, shares), 10**speculativeScaleFactor);
 
@@ -160,9 +162,9 @@ contract Pair is IPair {
 
         uint256 amount0 = PRBMath.mulDiv(r0, liquidity, _totalSupply);
         uint256 amount1 = PRBMath.mulDiv(r1, liquidity, _totalSupply);
-        if (!verifyInvariant(amount0, amount1, liquidity)) revert InvariantError();
-
         if (amount0 == 0 && amount1 == 0) revert InsufficientOutputError();
+
+        if (!verifyInvariant(r0 - amount0, r1 - amount1, _totalSupply - liquidity)) revert InvariantError();
         _burn(liquidity);
         _update(r0 - amount0, r1 - amount1);
 

--- a/test/WithdrawTest.t.sol
+++ b/test/WithdrawTest.t.sol
@@ -43,6 +43,8 @@ contract WithdrawTest is TestHelper {
 
         assertEq(pair.buffer(), 1 ether);
         assertEq(pair.totalSupply(), 1 ether);
+
+        pair.burn(cuh, 1 ether);
     }
 
     function testZeroBurn() public {


### PR DESCRIPTION
Verify the invariant on the current state of the pool before returning. The pair should never exit in a state where the invariant is not satisfied.